### PR TITLE
Set google public dns server (8.8.8.8) for dig command

### DIFF
--- a/src/Hostinger/ExecuteDigCommand.php
+++ b/src/Hostinger/ExecuteDigCommand.php
@@ -17,7 +17,7 @@ class ExecuteDigCommand
     {
         $lines   = [];
         $dnsType = strtoupper($recordType->getType());
-        $command = 'dig +noall +answer +time=' . escapeshellarg($this->timeout) . ' ' . escapeshellarg($dnsType) . ' ' . escapeshellarg($domain);
+        $command = 'dig @8.8.8.8 +noall +answer +time=' . escapeshellarg($this->timeout) . ' ' . escapeshellarg($dnsType) . ' ' . escapeshellarg($domain);
         exec($command, $lines);
         if (empty($lines)) {
             return [];


### PR DESCRIPTION
Set google public dns server (8.8.8.8) for dig command

Source https://support.rackspace.com/how-to/using-dig-to-query-nameservers/

issue https://github.com/hostinger/php-dig/issues/5