### PR TITLE
feat: Add dig lookup functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   ],
   "license": "MIT",
   "require": {
-    "php": ">=8.0",
+    "php": ">=8.1",
     "psr/log": "^1.0 || ^2.0 || ^3.0"
   },
   "require-dev": {

--- a/src/Command/DigCommand.php
+++ b/src/Command/DigCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Hostinger\Dig\Command;
+
+class DigCommand
+{
+    public function __construct(
+        private readonly string $name,
+        private readonly string $type,
+        private readonly ?DigOptions $options = null,
+        private readonly ?DigQuery $query = null,
+    ) {
+    }
+
+    public function toCliCommand(): string
+    {
+        $args = [];
+        $args[] = escapeshellcmd('dig');
+
+        if ($this->options) {
+            $args = array_merge($args, array_values($this->options->toCliOptions()));
+        }
+
+        if ($this->query) {
+            $args = array_merge($args, array_values($this->query->toCliQuery()));
+        }
+
+        $args[] = escapeshellarg($this->name);
+        $args[] = escapeshellarg($this->type);
+
+        return join(' ', $args);
+    }
+}

--- a/src/Command/DigOptions.php
+++ b/src/Command/DigOptions.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Hostinger\Dig\Command;
+
+class DigOptions
+{
+    public function __construct(
+        public readonly ?string $server = null,
+        public readonly ?string $name = null,
+        public readonly ?string $type = null,
+    ) {
+    }
+
+    public function toCliOptions(): array
+    {
+        $opts = [];
+
+        if ($this->server !== null) {
+            $opts['server'] = escapeshellarg('@' . $this->server);
+        }
+
+        if ($this->name !== null) {
+            $opts['name'] = '-q ' . escapeshellarg($this->name);
+        }
+
+        if ($this->type !== null) {
+            $opts['type'] = '-t ' . escapeshellarg($this->type);
+        }
+
+        return $opts;
+    }
+}

--- a/src/Command/DigQuery.php
+++ b/src/Command/DigQuery.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Hostinger\Dig\Command;
+
+class DigQuery
+{
+    public function __construct(
+        public readonly ?bool $all = null,
+        public readonly ?bool $answer = null,
+        public readonly ?bool $authority = null,
+        public readonly ?int $time = null,
+    ) {
+    }
+
+    public function toCliQuery(): array
+    {
+        $opts = [];
+
+        if ($this->all !== null) {
+            $opts['all'] = escapeshellarg('+' . ($this->all ? 'all' : 'noall'));
+        }
+
+        if ($this->answer !== null) {
+            $opts['answer'] = escapeshellarg('+' . ($this->answer ? 'answer' : 'noanswer'));
+        }
+
+        if ($this->authority !== null) {
+            $opts['authority'] = escapeshellarg('+' . ($this->authority ? 'authority' : 'noauthority'));
+        }
+
+        if ($this->time !== null) {
+            $opts['time'] = escapeshellarg('+time=' . $this->time);
+        }
+
+        return $opts;
+    }
+}

--- a/src/Exceptions/DigExecException.php
+++ b/src/Exceptions/DigExecException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Hostinger\Dig\Exceptions;
+
+use RuntimeException;
+
+class DigExecException extends RuntimeException
+{
+    public function __construct(string $reason)
+    {
+        parent::__construct("Unable to run dig: $reason");
+    }
+}

--- a/src/Exceptions/UnsupportedRecordTypeException.php
+++ b/src/Exceptions/UnsupportedRecordTypeException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Hostinger\Dig\Exceptions;
+
+use RuntimeException;
+
+class UnsupportedRecordTypeException extends RuntimeException
+{
+    public function __construct(int $type)
+    {
+        parent::__construct("Unsupported record type provided: $type");
+    }
+}

--- a/tests/Command/DigCommandTest.php
+++ b/tests/Command/DigCommandTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Hostinger\Dig\Tests\Command;
+
+use Generator;
+use Hostinger\Dig\Command\DigCommand;
+use Hostinger\Dig\Command\DigOptions;
+use Hostinger\Dig\Command\DigQuery;
+use PHPUnit\Framework\TestCase;
+
+class DigCommandTest extends TestCase
+{
+    public static function dataProvider(): Generator
+    {
+        yield 'basic' => [
+            [
+                'test.com',
+                'NS',
+            ],
+            "dig 'test.com' 'NS'",
+        ];
+
+        yield 'with options' => [
+            [
+                'test.com',
+                'NS',
+                new DigOptions(
+                    'ping.com',
+                ),
+            ],
+            "dig '@ping.com' 'test.com' 'NS'",
+        ];
+
+        yield 'with options and query' => [
+            [
+                'test.com',
+                'NS',
+                new DigOptions(
+                    'ping.com',
+                ),
+                new DigQuery(
+                    false,
+                    true,
+                    false,
+                    10,
+                ),
+            ],
+            "dig '@ping.com' '+noall' '+answer' '+noauthority' '+time=10' 'test.com' 'NS'",
+        ];
+
+        yield 'escapes args' => [
+            [
+                'test.com && exit 1',
+                'NS && ls -la',
+            ],
+            "dig 'test.com && exit 1' 'NS && ls -la'",
+        ];
+    }
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testToCliCommand(array $args, string $expected): void
+    {
+        $command = new DigCommand(...$args);
+
+        $this->assertEquals($expected, $command->toCliCommand());
+    }
+}

--- a/tests/Command/DigOptionsTest.php
+++ b/tests/Command/DigOptionsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Hostinger\Dig\Tests\Command;
+
+use Generator;
+use Hostinger\Dig\Command\DigOptions;
+use PHPUnit\Framework\TestCase;
+
+class DigOptionsTest extends TestCase
+{
+    public static function optionsDataProvider(): Generator
+    {
+        yield 'empty' => [
+            [
+                null,
+                null,
+                null,
+            ],
+            [],
+        ];
+
+        yield 'all set' => [
+            [
+                'test.com',
+                'ping.com',
+                'NS',
+            ],
+            [
+                'server' => escapeshellarg('@test.com'),
+                'name' => '-q ' . escapeshellarg('ping.com'),
+                'type' => '-t ' . escapeshellarg('NS'),
+            ],
+        ];
+
+        yield 'some set' => [
+            [
+                null,
+                null,
+                'NS',
+            ],
+            [
+                'type' => '-t ' . escapeshellarg('NS'),
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider optionsDataProvider
+     */
+    public function testToCliOptions(array $args, array $expected): void
+    {
+        $query = new DigOptions(...$args);
+
+        $this->assertEquals($expected, $query->toCliOptions());
+    }
+}

--- a/tests/Command/DigQueryTest.php
+++ b/tests/Command/DigQueryTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Hostinger\Dig\Tests\Command;
+
+use Generator;
+use Hostinger\Dig\Command\DigQuery;
+use PHPUnit\Framework\TestCase;
+
+class DigQueryTest extends TestCase
+{
+    public static function queryDataProvider(): Generator
+    {
+        yield 'empty' => [
+            [
+                null,
+                null,
+                null,
+                null,
+            ],
+            [],
+        ];
+
+        yield 'all set' => [
+            [
+                true,
+                true,
+                true,
+                10,
+            ],
+            [
+                'all' => escapeshellarg('+all'),
+                'answer' => escapeshellarg('+answer'),
+                'authority' => escapeshellarg('+authority'),
+                'time' => escapeshellarg('+time=10'),
+            ],
+        ];
+
+        yield 'all set to false' => [
+            [
+                false,
+                false,
+                false,
+                5,
+            ],
+            [
+                'all' => escapeshellarg('+noall'),
+                'answer' => escapeshellarg('+noanswer'),
+                'authority' => escapeshellarg('+noauthority'),
+                'time' => escapeshellarg('+time=5'),
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider queryDataProvider
+     */
+    public function testToCliQuery(array $args, array $expected): void
+    {
+        $query = new DigQuery(...$args);
+
+        $this->assertEquals($expected, $query->toCliQuery());
+    }
+}


### PR DESCRIPTION
Adds a new method `lookup` to the dig client, that allows the use of additional options and queries with the dig command.
Example:
```php
$result = $client->lookup(
    $domain,
    $type,
    new DigOptions(
        server: '8.8.8.8',
    ),
    new DigQuery(
        all: false,
        answer: true,
    ),
);
```

Also, increases the minimum PHP version requirement to 8.1 from 8.0